### PR TITLE
fix: create a copy of `appliance_data` when initializing an Appliance

### DIFF
--- a/pyhon/appliances/_base.py
+++ b/pyhon/appliances/_base.py
@@ -78,7 +78,7 @@ class Appliance:
         target_cls: type["Appliance"] = target_classes.get(appliance_type, cls)
 
         for zone in range(int(appliance_data.get("zone", "1"))):
-            appliance = target_cls(api, appliance_data, zone=zone)
+            appliance = target_cls(api, appliance_data.copy(), zone=zone)
             if appliance.mac_address:
                 try:
                     await appliance.load_commands()


### PR DESCRIPTION
This pull request includes a change to the `create_from_data` method in the `python/appliances/_base.py` file to ensure that the `appliance_data` dictionary is copied before being passed to the `target_cls` constructor. This prevents potential side effects from modifying the original `appliance_data` dictionary.

Indeed this is happening with devices with multiple zones: an error will occur when creating the second appliance (zone 1) since the `appliance_data` is changes inside the `Appliance` class and the format will be changed (https://github.com/IoTLabs-pl/pyhOn/blob/b869d137fddb865803efbcf9e9e940dd3c2a32f5/pyhon/appliances/_base.py#L54-L56)

See https://github.com/IoTLabs-pl/hon/issues/21#issuecomment-2652261253

* [`python/appliances/_base.py`](diffhunk://#diff-abae88af1dfd4a8d6edda22ccc9efcf2dc046e48d88e82a99e419d1d42cde723L81-R81): Modified `create_from_data` method to use `appliance_data.copy()` when creating `appliance` instances to avoid side effects.