### PR TITLE
chore: bump version to `0.18.0-beta.5`

### DIFF
--- a/pyhon/__version__.py
+++ b/pyhon/__version__.py
@@ -1,1 +1,1 @@
-__version__ = "0.18.0-beta.4"
+__version__ = "0.18.0-beta.5"


### PR DESCRIPTION
This pull request includes a small change to the `pyhon/__version__.py` file. The change updates the version number of the project from "0.18.0-beta.4" to "0.18.0-beta.5" to be able to release a new version.

Thanks for that Kuba!