### PR TITLE
fix: `str` trigger value not able to load

### DIFF
--- a/pyhon/rules.py
+++ b/pyhon/rules.py
@@ -35,7 +35,7 @@ class HonRuleSet:
         self,
         param_key: str,
         trigger_key: str,
-        trigger_data: dict[str, Any],
+        trigger_data: dict[str, Any] | str,
         extra: dict[str, str] | None = None,
     ) -> None:
         if not isinstance(trigger_data, dict):

--- a/pyhon/rules.py
+++ b/pyhon/rules.py
@@ -38,6 +38,8 @@ class HonRuleSet:
         trigger_data: dict[str, Any],
         extra: dict[str, str] | None = None,
     ) -> None:
+        if not isinstance(trigger_data, dict):
+            return
         trigger_key = trigger_key.replace("@", "")
         trigger_key = self._command.appliance.options.get(trigger_key, trigger_key)
         for multi_trigger_value, param_data in trigger_data.items():


### PR DESCRIPTION
Fix proposed in https://github.com/IoTLabs-pl/hon/issues/21#issuecomment-2656546972 by @zenntrix

This should be considered a temporary solution until a target API response parser is created.